### PR TITLE
install docopt + no need for csvfiles

### DIFF
--- a/roles/filter/tasks/filter.yml
+++ b/roles/filter/tasks/filter.yml
@@ -21,12 +21,13 @@
         - confluent-kafka==1.5
         - mysql-connector-python
         - mocpy
+        - docopt
 
-- name: Create csvfiles directory
-  file:
-      path: "{{ ansible_env.HOME }}/csvfiles/"
-      state: directory
-      mode: 0777
+#- name: Create csvfiles directory
+#  file:
+#      path: "{{ ansible_env.HOME }}/csvfiles/"
+#      state: directory
+#      mode: 0777
 
 # no longer required with current version of mariadb
 #- name: Modify apparmor so MySQL can write

--- a/roles/ingest/tasks/ingest.yml
+++ b/roles/ingest/tasks/ingest.yml
@@ -20,6 +20,7 @@
       - cassandra-driver
       - gkutils
       - gkdbutils
+      - docopt
 
 - name: Make sure the repo is up to date
   git: 

--- a/roles/lasair_service/tasks/main.yml
+++ b/roles/lasair_service/tasks/main.yml
@@ -23,6 +23,7 @@
         - mocpy
         - requests
         - mysql-connector-python
+        - docopt
 
 - name: Make sure the repo is up to date
   git: 


### PR DESCRIPTION
I have used docopt for command lines for lasair-service, filter, ingest, so have added it to the python packages.

Also -- I have removed the creation of the 'csvfiles' directory on the filter node that is no longer used.