### PR TITLE
Issue 110 servername

### DIFF
--- a/common/settings.py.j2
+++ b/common/settings.py.j2
@@ -94,7 +94,7 @@ WEB_DOMAIN             = '{{ lasair_name }}'
 
 # To include links in emails of filter results
 #LASAIR_URL             = 'lasair-iris.roe.ac.uk'
-LASAIR_URL             = '{{ domain }}'
+LASAIR_URL             = '{{ lasair_name }}.{{ domain }}'
 
 # The API calls this internal node for Sherlock
 SHERLOCK_SERVICE       = "{{ groups['sherlock'][0] }}"


### PR DESCRIPTION
Fixes #110.

I note that the variables LASAIR_URL and WEB_DOMAIN are actually somewhat confusingly named since the former is not in fact a URL and the latter is not a domain.