### PR TITLE
symlink for fits images

### DIFF
--- a/roles/webserver/tasks/main.yml
+++ b/roles/webserver/tasks/main.yml
@@ -158,6 +158,12 @@
     dest: "{{ ansible_env.HOME }}/lasair4/webserver/static/streams"
     state: link
 
+- name: Create symlink for fits images
+  file:
+    src: /mnt/cephfs/lasair/fits
+    dest: "{{ ansible_env.HOME }}/lasair4/webserver/static/fits"
+    state: link
+
 - name: Create Django superuser
   shell:
     chdir: "{{ ansible_env.HOME }}/lasair4/webserver"


### PR DESCRIPTION
One more symlink from the 'static' directory of the webserver to the cephfs where the fits files are stored.