### PR TITLE
Deploy tests - 164, 170, 171

### DIFF
--- a/common/settings.py.j2
+++ b/common/settings.py.j2
@@ -115,7 +115,7 @@ API_TOKEN              = '{{ settings.powerapi_token }}'
 # Comparing what we have processed with what ZTF has processed
 GRAFANA_USERNAME       = 'ztf'
 GRAFANA_PASSWORD       = '{{ settings.grafana_password }}'
-GRAFANA_URL            = "https://{{ lasair_name }}-svc.{{ domain }}/d/iILmd8-Wz/alerts"
+LASAIR_GRAFANA_URL     = "https://{{ lasair_name }}-svc.{{ domain }}/d/iILmd8-Wz/alerts"
 
 # Watchlist and Area control
 ############################

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,7 +1,6 @@
 ---
 - hosts: all
   gather_facts: true
-  tags: facts
 
 - hosts: all:!localhost
   gather_facts: false

--- a/roles/webserver/templates/settings.py.j2
+++ b/roles/webserver/templates/settings.py.j2
@@ -220,4 +220,5 @@ RECAPTCHA_PRIVATE_KEY= '{{ settings.recaptcha_private_key }}'
 RECAPTCHA_REQUIRED_SCORE = 0.7
 
 CSRF_TRUSTED_ORIGINS = ['https://{{ lasair_name }}.{{ domain }}']
+LASAIR_GRAFANA_URL = "https://{{ lasair_name }}-svc.{{ domain }}/d/iILmd8-Wz/alerts"
 

--- a/test.yaml
+++ b/test.yaml
@@ -129,15 +129,15 @@
     - name: check static file content
       assert:
         that: >
-          "{{ lookup('url', 'http://'+ansible_host+':8080/lasair/static/css/lasair-web.css', split_lines=false) | hash('md5') }}"
+          "{{ lookup('url', 'http://'+ansible_host+':8080/lasair/static/img/favicon/favicon.ico', split_lines=false) | hash('md5') }}"
           ==
-          "{{ lookup('url', 'https://raw.githubusercontent.com/lsst-uk/lasair4/'+lasair_version+'/webserver/staticfiles/css/lasair-web.css', split_lines=false) | hash('md5') }}"
+          "{{ lookup('url', 'https://raw.githubusercontent.com/lsst-uk/lasair4/'+lasair_version+'/webserver/static/img/favicon/favicon.ico', split_lines=false) | hash('md5') }}"
         quiet: true
     - name: check redirect works
       ansible.builtin.uri:
         url: "http://{{ lasair_name }}.{{ domain }}/"
         follow_redirects: false
-        status_code: 301
+        status_code: [301,302]
 
   tags: web
 - hosts: proxy

--- a/test.yaml
+++ b/test.yaml
@@ -4,7 +4,7 @@
 
 - hosts: all
   gather_facts: true
-  tags: facts
+#tags: facts
 
 - hosts: all
   gather_facts: false
@@ -70,23 +70,46 @@
   tags: kafka_pub
 - hosts: localhost
   gather_facts: false
+  vars_files:
+    - settings.yaml
+  vars:
+    kafka_settings: "{{ lookup('hashi_vault', 'secret='+vault.path+'/kafka url='+vault.url)}}"
   tasks:
     - name: set kafka test str
       set_fact: kafka_test_str="{{ lookup('community.general.random_string', special=false) }}"
+      tags: kafka,kafka_pub
     - name: test kafka produce
       shell: "echo {{ kafka_test_str }} | kafkacat -q -b {{ item }}:9092 -t deploy_test -P -p 0"
       loop: "{{ groups['kafka'] }}"
+      tags: kafka
     - name: test kafka consume
       shell: "kafkacat -q -b {{ item }}:9092 -t deploy_test -C -o -1 -c 1 -p 0"
       register: kafka_output
       loop: "{{ groups['kafka'] }}"
       changed_when: false
+      tags: kafka
     - name: check kafka output
       assert:
         that: "item == kafka_test_str"
         quiet: true
       loop: "{{ kafka_output.results | map(attribute='stdout') | list }}"
-  tags: kafka
+      tags: kafka
+    - name: test public kafka produce
+      shell: "echo {{ kafka_test_str }} | kafkacat -q -b {{ item }}:29092 -t deploy_test -P -p 0 -X security.protocol=SASL_PLAINTEXT -X sasl.mechanisms=SCRAM-SHA-256 -X sasl.username={{ kafka_settings.admin_username }} -X sasl.password={{ kafka_settings.admin_password }}"
+      loop: "{{ groups['kafka_pub'] }}"
+      tags: kafka_pub
+    - name: test public kafka consume
+      shell: "kafkacat -q -b {{ item }}:29092 -t deploy_test -C -o -1 -c 1 -p 0 -X security.protocol=SASL_PLAINTEXT -X sasl.mechanisms=SCRAM-SHA-256 -X sasl.username={{ kafka_settings.admin_username }} -X sasl.password={{ kafka_settings.admin_password }}"
+      register: kafka_pub_output
+      loop: "{{ groups['kafka_pub'] }}"
+      changed_when: false
+      tags: kafka_pub
+    - name: check public kafka output
+      assert:
+        that: "item == kafka_test_str"
+        quiet: true
+      loop: "{{ kafka_pub_output.results | map(attribute='stdout') | list }}"
+      tags: kafka_pub
 
 # webserver (+ api & proxy) tests
 - hosts: web


### PR DESCRIPTION
Fixes #164, #170, #171

- Change the static file deploy test
- Allow either HTTP 301 or 302 when testing redirect
- Change GRAFANA_URL to LASAIR_GRAFANA_URL and duplicate in web server settings
- Do a proper produce/consume deploy test on public kafka
- Remove requirement for "facts" tag in deploy.yaml and test.yaml as it is almost never not used